### PR TITLE
helm: add initial ci infrastrucutre to test/release inbucket helm charts

### DIFF
--- a/.github/workflows/charts-lint-test.yaml
+++ b/.github/workflows/charts-lint-test.yaml
@@ -1,0 +1,42 @@
+name: Lint and Test Charts
+
+on: pull_request
+
+jobs:
+  lint-test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Set up Helm
+        uses: azure/setup-helm@v1
+        with:
+          version: v3.4.0
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.7
+
+      - name: Set up chart-testing
+        uses: helm/chart-testing-action@v2.0.1
+
+      - name: Run chart-testing (list-changed)
+        id: list-changed
+        run: |
+          changed=$(ct list-changed)
+          if [[ -n "$changed" ]]; then
+            echo "::set-output name=changed::true"
+          fi
+
+      - name: Run chart-testing (lint)
+        run: ct lint --config helm-charts/ct.yaml
+
+      - name: Create kind cluster
+        uses: helm/kind-action@v1.0.0
+        if: steps.list-changed.outputs.changed == 'true'
+
+      - name: Run chart-testing (install)
+        run: ct install --config helm-charts/ct.yaml

--- a/.github/workflows/charts-release.yaml
+++ b/.github/workflows/charts-release.yaml
@@ -1,0 +1,24 @@
+name: Release Charts
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "$GITHUB_ACTOR"
+          git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
+      - name: Run chart-releaser
+        uses: helm/chart-releaser-action@v1.2.0
+        env:
+          CR_TOKEN: "${{ secrets.GITHUB_TOKEN }}"

--- a/helm-charts/ct.yaml
+++ b/helm-charts/ct.yaml
@@ -1,0 +1,8 @@
+# See https://github.com/helm/chart-testing#configuration
+chart-dirs:
+  - helm-charts
+remote: origin
+target-branch: main
+upgrade: true
+chart-repos:
+  - stable=https://charts.helm.sh/stable


### PR DESCRIPTION
This PR adds the initial CI infrastructure to test and release the helm charts


@jhillyerd can you enable the DCO bot to check for the DCO sign commits?

