### PR TITLE
Use bats/bats image for testing

### DIFF
--- a/helm-charts/inbucket/Chart.yaml
+++ b/helm-charts/inbucket/Chart.yaml
@@ -3,7 +3,7 @@ description: Disposable webmail server (similar to Mailinator) with built in SMT
 name: inbucket
 type: application
 appVersion: 3.0.0
-version: 2.0.1
+version: 2.1.0
 keywords:
   - inbucket
   - mail

--- a/helm-charts/inbucket/templates/tests/inbucket-test.yaml
+++ b/helm-charts/inbucket/templates/tests/inbucket-test.yaml
@@ -10,33 +10,21 @@ metadata:
   annotations:
     "helm.sh/hook": test-success
 spec:
-  initContainers:
-    - name: "test-framework"
-      image: "dduportal/bats:0.4.0"
+  containers:
+    - name: {{ .Release.Name }}-test
+      image: "bats/bats"
       command:
       - "bash"
       - "-c"
       - |
-        set -ex
-        # copy bats to tools dir
-        cp -R /usr/local/libexec/ /tools/bats/
-      volumeMounts:
-      - mountPath: /tools
-        name: tools
-  containers:
-    - name: {{ .Release.Name }}-test
-      image: "dduportal/bats:0.4.0"
-      command: ["/tools/bats/bats", "-t", "/tests/run.sh"]
+        apk add curl
+        bats -t /tests/run.sh
       volumeMounts:
       - mountPath: /tests
         name: tests
         readOnly: true
-      - mountPath: /tools
-        name: tools
   volumes:
   - name: tests
     configMap:
       name: {{ include "inbucket.name" . }}-tests
-  - name: tools
-    emptyDir: {}
   restartPolicy: Never


### PR DESCRIPTION
dduportal/bats:0.4.0 is outdated and cannot be pulled from docker hub anymore.

This means that the tests were not run-able.