### PR TITLE
Support the ingressClassName option in the Ingress

### DIFF
--- a/helm-charts/inbucket/Chart.yaml
+++ b/helm-charts/inbucket/Chart.yaml
@@ -3,7 +3,7 @@ description: Disposable webmail server (similar to Mailinator) with built in SMT
 name: inbucket
 type: application
 appVersion: 3.0.0
-version: 2.1.0
+version: 2.2.0
 keywords:
   - inbucket
   - mail

--- a/helm-charts/inbucket/templates/ingress.yaml
+++ b/helm-charts/inbucket/templates/ingress.yaml
@@ -17,6 +17,9 @@ metadata:
       {{ $key }}: {{ $value | quote }}
     {{- end }}
 spec:
+{{- if .Values.ingress.className }}
+  ingressClassName: {{ .Values.ingress.className }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/helm-charts/inbucket/values.yaml
+++ b/helm-charts/inbucket/values.yaml
@@ -56,6 +56,7 @@ extraEnv:
 
 ingress:
   enabled: false
+  #className: your-custom-ingress-class
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/helm-charts/inbucket/values.yaml
+++ b/helm-charts/inbucket/values.yaml
@@ -56,7 +56,7 @@ extraEnv:
 
 ingress:
   enabled: false
-  #className: your-custom-ingress-class
+  #className: your-custom-ingress-class-name
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"

--- a/helm-charts/inbucket/values.yaml
+++ b/helm-charts/inbucket/values.yaml
@@ -56,7 +56,7 @@ extraEnv:
 
 ingress:
   enabled: false
-  #className: your-custom-ingress-class-name
+  className: ""
   annotations: {}
     # kubernetes.io/ingress.class: nginx
     # kubernetes.io/tls-acme: "true"


### PR DESCRIPTION
The Ingress API object has an ingressClassName option, which is useful for cases where people are using more than one Ingress in a cluster. This allows us to specify which ingress to attach to:

https://kubernetes.io/docs/concepts/services-networking/ingress/#the-ingress-resource

This PR adds the parameter as an optional one, with the default behaviour (where the option isn't specified in values.yaml) being backwards compatible (ie. unchanged).