### PR TITLE
removing not needed annotations

### DIFF
--- a/helm-charts/inbucket/templates/configmap.yaml
+++ b/helm-charts/inbucket/templates/configmap.yaml
@@ -6,7 +6,5 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "inbucket.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "inbucket.chart" . }}
 data:
 {{ toYaml .Values.extraEnv | indent 2 }}

--- a/helm-charts/inbucket/templates/configmap.yaml
+++ b/helm-charts/inbucket/templates/configmap.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: {{ include "inbucket.name" . }}-configmap
-  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "inbucket.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}

--- a/helm-charts/inbucket/templates/deployment.yaml
+++ b/helm-charts/inbucket/templates/deployment.yaml
@@ -4,10 +4,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "inbucket.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "inbucket.chart" . }}
   name: {{ include "inbucket.fullname" . }}
-  namespace: {{ .Release.Namespace }}
 spec:
   selector:
     matchLabels:
@@ -22,8 +19,6 @@ spec:
       labels:
         app.kubernetes.io/name: {{ include "inbucket.name" . }}
         app.kubernetes.io/instance: {{ .Release.Name }}
-        app.kubernetes.io/managed-by: {{ .Release.Service }}
-        helm.sh/chart: {{ include "inbucket.chart" . }}
     spec:
       containers:
         - name: {{ include "inbucket.name" . }}

--- a/helm-charts/inbucket/templates/ingress.yaml
+++ b/helm-charts/inbucket/templates/ingress.yaml
@@ -6,12 +6,9 @@ apiVersion: {{ include "inbucket.ingress.apiVersion" . }}
 kind: Ingress
 metadata:
   name: {{ $fullName }}
-  namespace: {{ .Release.Namespace }}
   labels:
     app.kubernetes.io/name: {{ include "inbucket.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "inbucket.chart" . }}
   annotations:
     {{- range $key, $value := .Values.ingress.annotations }}
       {{ $key }}: {{ $value | quote }}

--- a/helm-charts/inbucket/templates/service.yaml
+++ b/helm-charts/inbucket/templates/service.yaml
@@ -8,10 +8,7 @@ metadata:
   labels:
     app.kubernetes.io/name: {{ include "inbucket.name" . }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-    app.kubernetes.io/managed-by: {{ .Release.Service }}
-    helm.sh/chart: {{ include "inbucket.chart" . }}
   name: {{ include "inbucket.fullname" . }}
-  namespace: {{ .Release.Namespace }}
 spec:
   type: "{{ .Values.service.type }}"
 {{- if .Values.service.externalIPs }}


### PR DESCRIPTION
I take it these annotations are used for helm management. But it is best to let helm add them in case of helm changing them and using different ones (which I believe it has already done). Also, best to let helm add the namespaces. Who knows, maybe they have the options for multi-namespaces releases in the future