### PR TITLE
Fix labels in NOTES.txt

### DIFF
--- a/helm-charts/inbucket/Chart.yaml
+++ b/helm-charts/inbucket/Chart.yaml
@@ -3,7 +3,7 @@ description: Disposable webmail server (similar to Mailinator) with built in SMT
 name: inbucket
 type: application
 appVersion: 3.0.0
-version: 2.2.1
+version: 2.2.2
 keywords:
   - inbucket
   - mail

--- a/helm-charts/inbucket/templates/NOTES.txt
+++ b/helm-charts/inbucket/templates/NOTES.txt
@@ -6,7 +6,7 @@ If you'd like to test your instance, forward the ports locally:
 Web UI:
 =======
 
-export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "inbucket.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "inbucket.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
 kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.service.port.http }}
 
 or
@@ -16,7 +16,7 @@ kubectl port-forward --namespace {{ .Release.Namespace }} service/{{ include "in
 SMTP Server:
 ============
 
-export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "inbucket.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "inbucket.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
 kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.service.port.smtp }}
 
 or
@@ -26,7 +26,7 @@ kubectl port-forward --namespace {{ .Release.Namespace }} service/{{ include "in
 POP3 Server:
 ============
 
-export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ include "inbucket.name" . }},release={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
+export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app.kubernetes.io/name={{ include "inbucket.name" . }},app.kubernetes.io/instance={{ .Release.Name }}" -o jsonpath="{.items[0].metadata.name}")
 kubectl port-forward --namespace {{ .Release.Namespace }} $POD_NAME {{ .Values.service.port.pop3 }}
 
 or


### PR DESCRIPTION
The example label names of app & release did not work for me.

My pod had these labels

```
Labels:           app.kubernetes.io/instance=my-inbucket
                  app.kubernetes.io/managed-by=Helm
                  app.kubernetes.io/name=inbucket
                  helm.sh/chart=inbucket-2.2.1
                  pod-template-hash=7bdf65b86
```