### PR TITLE
Add tolerations and local storage to the deployment

### DIFF
--- a/helm-charts/inbucket/Chart.yaml
+++ b/helm-charts/inbucket/Chart.yaml
@@ -3,7 +3,7 @@ description: Disposable webmail server (similar to Mailinator) with built in SMT
 name: inbucket
 type: application
 appVersion: 3.0.0
-version: 2.2.3
+version: 2.3.0
 keywords:
   - inbucket
   - mail

--- a/helm-charts/inbucket/Chart.yaml
+++ b/helm-charts/inbucket/Chart.yaml
@@ -3,7 +3,7 @@ description: Disposable webmail server (similar to Mailinator) with built in SMT
 name: inbucket
 type: application
 appVersion: 3.0.0
-version: 2.2.2
+version: 2.2.3
 keywords:
   - inbucket
   - mail

--- a/helm-charts/inbucket/templates/_helpers.tpl
+++ b/helm-charts/inbucket/templates/_helpers.tpl
@@ -69,3 +69,10 @@ Return if ingress supports pathType.
 {{- define "inbucket.ingress.supportsPathType" -}}
   {{- or (eq (include "inbucket.ingress.isStable" .) "true") (and (eq (include "inbucket.ingress.apiVersion" .) "networking.k8s.io/v1beta1") (semverCompare ">= 1.18-0" .Capabilities.KubeVersion.Version)) -}}
 {{- end -}}
+
+{{/*
+Return if persistence is enabled.
+*/}}
+{{- define "inbucket.persistenceEnabled" -}}
+  {{- and ( and ( hasKey .Values "persistence" ) ( hasKey .Values.persistence "enabled" ) ) ( eq .Values.persistence.enabled true ) -}}
+{{- end -}}

--- a/helm-charts/inbucket/templates/deployment.yaml
+++ b/helm-charts/inbucket/templates/deployment.yaml
@@ -54,7 +54,23 @@ spec:
             timeoutSeconds: 5
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+        {{- if .Values.persistence.enabled }}
+          volumeMounts:
+            - mountPath: {{ .Values.persistence.path }}
+              name: {{ include "inbucket.fullname" . }}
+              readOnly: false
+        {{- end }}
     {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}
+    {{- end }}
+    {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 6 }}
+    {{- end }}
+    {{- if .Values.persistence.enabled }}
+      volumes:
+        - name: {{ include "inbucket.fullname" . }}
+          persistentVolumeClaim:
+            claimName: {{ include "inbucket.fullname" . }}
     {{- end }}

--- a/helm-charts/inbucket/templates/deployment.yaml
+++ b/helm-charts/inbucket/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- $persistence := eq (include "inbucket.persistenceEnabled" .) "true" -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -54,7 +55,7 @@ spec:
             timeoutSeconds: 5
           resources:
 {{ toYaml .Values.resources | indent 12 }}
-        {{- if .Values.persistence.enabled }}
+        {{- if $persistence }}
           volumeMounts:
             - mountPath: {{ .Values.persistence.path }}
               name: {{ include "inbucket.fullname" . }}
@@ -68,7 +69,7 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 6 }}
     {{- end }}
-    {{- if .Values.persistence.enabled }}
+    {{- if $persistence}}
       volumes:
         - name: {{ include "inbucket.fullname" . }}
           persistentVolumeClaim:

--- a/helm-charts/inbucket/templates/pvc.yaml
+++ b/helm-charts/inbucket/templates/pvc.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.persistence.enabled }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "inbucket.fullname" . }}
+  labels:
+    app.kubernetes.io/name: {{ include "inbucket.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+    helm.sh/chart: {{ include "inbucket.chart" . }}
+spec:
+  accessModes:
+    - {{ .Values.persistence.accessMode }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+  storageClassName: {{ .Values.persistence.className }}
+{{- end }}

--- a/helm-charts/inbucket/templates/pvc.yaml
+++ b/helm-charts/inbucket/templates/pvc.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.persistence.enabled }}
+{{- if eq (include "inbucket.persistenceEnabled" .) "true" }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -10,7 +10,7 @@ metadata:
     helm.sh/chart: {{ include "inbucket.chart" . }}
 spec:
   accessModes:
-    - {{ .Values.persistence.accessMode }}
+    - {{ default .Values.persistence.accessMode "ReadWriteOnce" }}
   resources:
     requests:
       storage: {{ .Values.persistence.size }}

--- a/helm-charts/inbucket/values.yaml
+++ b/helm-charts/inbucket/values.yaml
@@ -74,3 +74,10 @@ ingress:
 
 podAnnotations: {}
 resources: {}
+
+persistence:
+  enabled: false
+  path: /storage
+  size: 1Gi
+  className:
+  accessMode: ReadWriteOnce


### PR DESCRIPTION
The deployment has [affinity](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity) in the form of nodeSelector but not [tolerations](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/) for taints. This PR adds optional tolerations to the deployment resource.

Also, an optional persistent volume claim is created if enabled in the values; this allows the deployment to have a persistent storage to keep the emails, in case it is required.
The environment variables for the storage have to be set manually in the values like:
```yaml
extraEnv:
  INBUCKET_STORAGE_TYPE: "file"
  INBUCKET_STORAGE_PARAMS: "path:/storage"
```