### PR TITLE
use a tag in the bats image

### DIFF
--- a/helm-charts/inbucket/Chart.yaml
+++ b/helm-charts/inbucket/Chart.yaml
@@ -3,7 +3,7 @@ description: Disposable webmail server (similar to Mailinator) with built in SMT
 name: inbucket
 type: application
 appVersion: 3.0.0
-version: 2.3.0
+version: 2.3.1
 keywords:
   - inbucket
   - mail

--- a/helm-charts/inbucket/templates/tests/inbucket-test.yaml
+++ b/helm-charts/inbucket/templates/tests/inbucket-test.yaml
@@ -12,7 +12,7 @@ metadata:
 spec:
   containers:
     - name: {{ .Release.Name }}-test
-      image: "bats/bats"
+      image: "bats/bats:v1.10.0@sha256:33d5909905442e39afdb29af693516f213ace6b8100045d408475d5bd15196cb"
       command:
       - "bash"
       - "-c"


### PR DESCRIPTION
When trying to bundle and deploy inbucket in a complete offline env, it returns because of not using a specific tag in the bats image.

Using a latest stable release tag, instead of latest by default.